### PR TITLE
http: close a file before to be logged

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1946,6 +1946,12 @@ int HTPCallbackResponseBodyData(htp_tx_data_t *d)
         HtpBodyAppendChunk(tx_ud, &tx_ud->response_body, (uint8_t *)d->data, len);
 
         HtpResponseBodyHandle(hstate, tx_ud, d->tx, (uint8_t *)d->data, (uint32_t)d->len);
+    } else {
+        if (tx_ud->tcflags & HTP_FILENAME_SET) {
+            SCLogDebug("closing file that was being stored");
+            (void)HTPFileClose(hstate, NULL, 0, FILE_TRUNCATED, STREAM_TOCLIENT);
+            tx_ud->tcflags &= ~HTP_FILENAME_SET;
+        }
     }
 
     /* set the new chunk flag */


### PR DESCRIPTION
In some conditions, if filestore keyword is used
with http, the output could be wrong.

For example:
{... "app_proto":"http","fileinfo":{"filename":"\/file.pdf","state":"CLOSED","stored":false,"size":1049292,"tx_id":0}}

"state":"CLOSED","stored":false should be "state":"TRUNCATED","stored":true.

To reproduce the issue the stream.reassembly.depth size must be greater
than request/response-body-limit size.

This happens because the state and flags are not set properly,
in this case a file is logged before, then closed (HTPFileClose).

The logic of this patch is to close a file when we are above
the limits, such that the proper state and flags can be set
and the file will be logged correctly.