### PR TITLE
log/pcap: dump segments of both sides of tcp session.

### DIFF
--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -565,17 +565,11 @@ static void PcapLogDumpSegments(
         PcapLogThreadData *td, PcapLogCompressionData *connp, const Packet *p)
 {
     uint8_t flag;
-    /*  check which side is packet */
-    if (p->flowflags & FLOW_PKT_TOSERVER) {
-        flag = STREAM_DUMP_TOCLIENT;
-    } else {
-        flag = STREAM_DUMP_TOSERVER;
-    }
-    flag |= STREAM_DUMP_HEADERS;
+    flag = STREAM_DUMP_HEADERS;
 
     /* Loop on segment from this side */
     struct PcapLogCallbackContext data = { td->pcap_log, connp, td->buf };
-    StreamSegmentForEach(p, flag, PcapLogSegmentCallback, (void *)&data);
+    StreamSegmentForSession(p, flag, PcapLogSegmentCallback, (void *)&data);
 }
 
 /**
@@ -690,6 +684,19 @@ static int PcapLog (ThreadVars *t, void *thread_data, const Packet *p)
 #else
             PcapLogDumpSegments(td, NULL, p);
 #endif
+            /* PcapLogDumpSegment has writtens over the PcapLogData variables so need to update */
+            pl->h->ts.tv_sec = p->ts.tv_sec;
+            pl->h->ts.tv_usec = p->ts.tv_usec;
+            if (IS_TUNNEL_PKT(p)) {
+                rp = p->root;
+                pl->h->caplen = GET_PKT_LEN(rp);
+                pl->h->len = GET_PKT_LEN(rp);
+                len = sizeof(*pl->h) + GET_PKT_LEN(rp);
+            } else {
+                pl->h->caplen = GET_PKT_LEN(p);
+                pl->h->len = GET_PKT_LEN(p);
+                len = sizeof(*pl->h) + GET_PKT_LEN(p);
+            }
         }
     }
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -6209,12 +6209,13 @@ void StreamTcpDetectLogFlush(ThreadVars *tv, StreamTcpThread *stt, Flow *f, Pack
 }
 
 /**
- * \brief Run callback function on each TCP segment
+ * \brief Run callback function on each TCP segment in a single direction.
  *
  * \note when stream engine is running in inline mode all segments are used,
  *       in IDS/non-inline mode only ack'd segments are iterated.
  *
  * \note Must be called under flow lock.
+ * \var flag determines the direction to run callback on (either to server or to client).
  *
  * \return -1 in case of error, the number of segment in case of success
  *
@@ -6256,6 +6257,103 @@ int StreamTcpSegmentForEach(const Packet *p, uint8_t flag, StreamSegmentCallback
         if (ret != 1) {
             SCLogDebug("Callback function has failed");
             return -1;
+        }
+
+        cnt++;
+    }
+    return cnt;
+}
+
+/**
+ * \brief Run callback function on each TCP segment in both directions of a session.
+ *
+ * \note when stream engine is running in inline mode all segments are used,
+ *       in IDS/non-inline mode only ack'd segments are iterated.
+ *
+ * \note Must be called under flow lock.
+ *
+ * \return -1 in case of error, the number of segment in case of success
+ *
+ */
+int StreamTcpSegmentForSession(
+        const Packet *p, uint8_t flag, StreamSegmentCallback CallbackFunc, void *data)
+{
+    TcpSession *ssn = NULL;
+    TcpStream *server_stream = NULL;
+    TcpStream *client_stream = NULL;
+    int ret = 0;
+    int cnt = 0;
+
+    if (p->flow == NULL)
+        return 0;
+
+    ssn = (TcpSession *)p->flow->protoctx;
+
+    if (ssn == NULL) {
+        return 0;
+    }
+
+    server_stream = &(ssn->server);
+    client_stream = &(ssn->client);
+
+    TcpSegment *server_node = RB_ROOT(&(server_stream->seg_tree));
+    TcpSegment *client_node = RB_ROOT(&(client_stream->seg_tree));
+    if (server_node == NULL || client_node == NULL) {
+        return cnt;
+    }
+
+    while (server_node != NULL || client_node != NULL) {
+        const uint8_t *seg_data;
+        uint32_t seg_datalen;
+        if (server_node == NULL) {
+            /*
+             * This means the server side RB Tree has been completely searched,
+             * thus all that remains is to dump the TcpSegments on the client
+             * side.
+             */
+            StreamingBufferSegmentGetData(
+                    &client_stream->sb, &client_node->sbseg, &seg_data, &seg_datalen);
+            ret = CallbackFunc(p, client_node, data, seg_data, seg_datalen);
+            if (ret != 1) {
+                SCLogDebug("Callback function has failed");
+                return -1;
+            }
+            client_node = TCPSEG_RB_NEXT(client_node);
+        } else if (client_node == NULL) {
+            /*
+             * This means the client side RB Tree has been completely searched,
+             * thus all that remains is to dump the TcpSegments on the server
+             * side.
+             */
+            StreamingBufferSegmentGetData(
+                    &server_stream->sb, &server_node->sbseg, &seg_data, &seg_datalen);
+            ret = CallbackFunc(p, server_node, data, seg_data, seg_datalen);
+            if (ret != 1) {
+                SCLogDebug("Callback function has failed");
+                return -1;
+            }
+            server_node = TCPSEG_RB_NEXT(server_node);
+        } else {
+            if TIMEVAL_EARLIER (client_node->pcap_hdr_storage->ts,
+                    server_node->pcap_hdr_storage->ts) {
+                StreamingBufferSegmentGetData(
+                        &client_stream->sb, &client_node->sbseg, &seg_data, &seg_datalen);
+                ret = CallbackFunc(p, client_node, data, seg_data, seg_datalen);
+                if (ret != 1) {
+                    SCLogDebug("Callback function has failed");
+                    return -1;
+                }
+                client_node = TCPSEG_RB_NEXT(client_node);
+            } else {
+                StreamingBufferSegmentGetData(
+                        &server_stream->sb, &server_node->sbseg, &seg_data, &seg_datalen);
+                ret = CallbackFunc(p, server_node, data, seg_data, seg_datalen);
+                if (ret != 1) {
+                    SCLogDebug("Callback function has failed");
+                    return -1;
+                }
+                server_node = TCPSEG_RB_NEXT(server_node);
+            }
         }
 
         cnt++;

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -124,6 +124,8 @@ Packet *StreamTcpPseudoSetup(Packet *, uint8_t *, uint32_t);
 int StreamTcpSegmentForEach(const Packet *p, uint8_t flag,
                         StreamSegmentCallback CallbackFunc,
                         void *data);
+int StreamTcpSegmentForSession(
+        const Packet *p, uint8_t flag, StreamSegmentCallback CallbackFunc, void *data);
 void StreamTcpReassembleConfigEnableOverlapCheck(void);
 void TcpSessionSetReassemblyDepth(TcpSession *ssn, uint32_t size);
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -30,9 +30,10 @@
 #include "stream-tcp.h"
 #include "flow-util.h"
 
-/** \brief Run callback for all segments
+/** \brief Run callback for all segments in a single direction.
  *
  * Must be called under flow lock.
+ * \var flag determines the direction to run callback on (either to server or to client).
  *
  * \return -1 in case of error, the number of segment in case of success
  */
@@ -41,6 +42,31 @@ int StreamSegmentForEach(const Packet *p, uint8_t flag, StreamSegmentCallback Ca
     switch(p->proto) {
         case IPPROTO_TCP:
             return StreamTcpSegmentForEach(p, flag, CallbackFunc, data);
+            break;
+#ifdef DEBUG
+        case IPPROTO_UDP:
+            SCLogWarning(SC_ERR_UNKNOWN_PROTOCOL, "UDP is currently unsupported");
+            break;
+        default:
+            SCLogWarning(SC_ERR_UNKNOWN_PROTOCOL, "This protocol is currently unsupported");
+            break;
+#endif
+    }
+    return 0;
+}
+
+/** \brief Run callback for all segments on both directions of the session
+ *
+ * Must be called under flow lock.
+ *
+ * \return -1 in case of error, the number of segments in case of success.
+ */
+int StreamSegmentForSession(
+        const Packet *p, uint8_t flag, StreamSegmentCallback CallbackFunc, void *data)
+{
+    switch (p->proto) {
+        case IPPROTO_TCP:
+            return StreamTcpSegmentForSession(p, flag, CallbackFunc, data);
             break;
 #ifdef DEBUG
         case IPPROTO_UDP:

--- a/src/stream.h
+++ b/src/stream.h
@@ -45,6 +45,8 @@ typedef int (*StreamSegmentCallback)(
 int StreamSegmentForEach(const Packet *p, uint8_t flag,
                          StreamSegmentCallback CallbackFunc,
                          void *data);
+int StreamSegmentForSession(
+        const Packet *p, uint8_t flag, StreamSegmentCallback CallbackFunc, void *data);
 
 #endif /* __STREAM_H__ */
 


### PR DESCRIPTION
This patch updates tcp segment dumping to dump segments
from both sides of the session in order when capturing
alerts and tags.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- This should do the trick for getting both sides of the session to be dumped.
- One thing I've noticed in evaluating this is that there seems to be a difference in behaviour between alerts mode and tag mode for conditionals and I am wondering if you can provide some insight:
   - It looks like only alerts mode is properly marking the "first packet to alert" and so DumpTcpSegments is only getting triggered in that mode. For some reason in tag mode it's behind by 1 packet, i.e. PcapLog function is triggered one packet later and thus that packet isn't marked as "first packet to alert" and so DumpTcpSegments isn't triggered. I think we can either try to figure out why that is or we can change the conditions for triggering DumpTcpSegments (not sure what the best would be) so that it is hit in both modes. 

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
